### PR TITLE
add nice +1 to python apps and transmission

### DIFF
--- a/packages/thoradia/addons/couchpotato/source/bin/couchpotato.start
+++ b/packages/thoradia/addons/couchpotato/source/bin/couchpotato.start
@@ -3,6 +3,7 @@
 . /etc/profile
 oe_setup_addon service.couchpotato
 
+nice -1                                      \
 python $ADDON_DIR/CouchPotato/CouchPotato.py \
        --config_file $ADDON_HOME/settings.conf \
        --data_dir $ADDON_HOME

--- a/packages/thoradia/addons/headphones/source/bin/headphones.start
+++ b/packages/thoradia/addons/headphones/source/bin/headphones.start
@@ -3,5 +3,6 @@
 . /etc/profile
 oe_setup_addon service.headphones
 
+nice -1                                    \
 python $ADDON_DIR/headphones/Headphones.py \
        --datadir="$ADDON_HOME"

--- a/packages/thoradia/addons/sabnzbd/source/bin/sabnzbd.start
+++ b/packages/thoradia/addons/sabnzbd/source/bin/sabnzbd.start
@@ -3,6 +3,7 @@
 . /etc/profile
 oe_setup_addon service.sabnzbd
 
+nice -1                              \
 python $ADDON_DIR/SABnzbd/SABnzbd.py \
        --config-file $ADDON_HOME/ \
        --server "$sabnzbd_server"

--- a/packages/thoradia/addons/sickrage/source/bin/sickrage.start
+++ b/packages/thoradia/addons/sickrage/source/bin/sickrage.start
@@ -3,5 +3,6 @@
 . /etc/profile
 oe_setup_addon service.sickrage
 
+nice -1                                 \
 python $ADDON_DIR/SickRage/SickBeard.py \
        --datadir="$ADDON_HOME"

--- a/packages/thoradia/addons/transmission/source/bin/transmission.start
+++ b/packages/thoradia/addons/transmission/source/bin/transmission.start
@@ -26,6 +26,7 @@ fi
 
 eval "EVENT_NOEPOLL=1                          \
       TRANSMISSION_WEB_HOME=\"$ADDON_DIR/web\" \
+      nice -1                                  \
       transmission-daemon                      \
       --allowed        \"$tx_allowed\"         \
       --config-dir     \"$ADDON_HOME\"         \
@@ -34,4 +35,3 @@ eval "EVENT_NOEPOLL=1                          \
       --watch-dir      \"$tx_watch\"           \
       $incomplete                              \
       $tx_auth"
-


### PR DESCRIPTION
This PR is based on a couple of assumptions:

* kodi is the primary app on any LibreELEC host
* it is likely that the desire of a user is to always prioritize kodi CPU cycles over other CPU-intensive background apps such as transmission and sickrage

Tested on transmission and sickrage. Should be fine for the other 3 apps in this PR.