### PR TITLE
transmission: add command-line utils

### DIFF
--- a/packages/thoradia/addons/transmission/changelog.txt
+++ b/packages/thoradia/addons/transmission/changelog.txt
@@ -1,3 +1,6 @@
+24
+- Add command-line utils (transmission-remote, transmission-create, transmission-edit and transmission-show)
+
 23
 - Update libevent to 2.1.12-stable
 

--- a/packages/thoradia/addons/transmission/package.mk
+++ b/packages/thoradia/addons/transmission/package.mk
@@ -1,7 +1,7 @@
 PKG_NAME="transmission"
 PKG_VERSION="3.00"
 PKG_SHA256="9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2"
-PKG_REV="23"
+PKG_REV="24"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.transmissionbt.com/"
 PKG_URL="https://github.com/transmission/transmission-releases/raw/master/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -21,7 +21,7 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_DAEMON=ON \
                        -DENABLE_GTK=OFF \
                        -DENABLE_QT=OFF \
                        -DENABLE_MAC=OFF \
-                       -DENABLE_UTILS=OFF \
+                       -DENABLE_UTILS=ON \
                        -DENABLE_CLI=ON \
                        -DENABLE_TESTS=OFF \
                        -DENABLE_LIGHTWEIGHT=OFF \


### PR DESCRIPTION
This adds the command line utils (transmission-remote, transmission-show, transmission-edit and transmission-create).

I found [an issue](https://github.com/thoradia/LibreELEC.tv/issues/73) opened a few months ago asking for transmission-remote to be added, and the CLI option was enabled as a result. This option enables `transmission-cli` but that's an extremely limited tool. `transmission-remote` is far more useful.